### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,10 @@ dependencies {
     include xplibs.project
 
     include(libs.lib.landingpage) { exclude group: 'com.enonic.xp' }
-    include(libs.lib.menu)        { exclude group: 'com.enonic.xp' }
+    include libs.lib.menu
     include(libs.lib.thymeleaf)   { exclude group: 'com.enonic.xp' }
     include(libs.lib.urlredirect) { exclude group: 'com.enonic.xp' }
-    include(libs.lib.util)        { exclude group: 'com.enonic.xp' }
+    include libs.lib.util
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,10 @@ dependencies {
     include xplibs.portal
     include xplibs.project
 
-    include(libs.lib.landingpage) { exclude group: 'com.enonic.xp' }
+    include libs.lib.landingpage
     include libs.lib.menu
-    include(libs.lib.thymeleaf)   { exclude group: 'com.enonic.xp' }
-    include(libs.lib.urlredirect) { exclude group: 'com.enonic.xp' }
+    include libs.lib.thymeleaf
+    include libs.lib.urlredirect
     include libs.lib.util
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-landingpage = "2.0.1"
+landingpage = "3.0.0-SNAPSHOT"
 menu = "5.0.0-SNAPSHOT"
 thymeleaf = "3.0.0-SNAPSHOT"
-urlredirect = "3.0.1"
+urlredirect = "4.0.0-SNAPSHOT"
 util = "4.0.0-SNAPSHOT"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 landingpage = "2.0.1"
-menu = "4.2.1"
+menu = "5.0.0-SNAPSHOT"
 thymeleaf = "3.0.0-SNAPSHOT"
 urlredirect = "3.0.1"
-util = "3.1.1"
+util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-landingpage = { module = "com.enonic.lib:lib-landingpage", version.ref = "landingpage" }


### PR DESCRIPTION
## Summary

Pin all enonic libs whose `master` branches have been upgraded to XP 8 to their next-major SNAPSHOTs (resolved from the existing `xp.enonicRepo('dev')` declaration).

### Versions bumped

| Library | Before | After |
|---|---|---|
| `com.enonic.lib:lib-util` | `3.1.1` | `4.0.0-SNAPSHOT` (resolved from dev repo) |
| `com.enonic.lib:lib-menu` | `4.2.1` | `5.0.0-SNAPSHOT` (resolved from dev repo) |
| `com.enonic.lib:lib-landingpage` | `2.0.1` | `3.0.0-SNAPSHOT` (resolved from dev repo) |
| `com.enonic.lib:lib-urlredirect` | `3.0.1` | `4.0.0-SNAPSHOT` (resolved from dev repo) |
| `com.enonic.lib:lib-thymeleaf` | `3.0.0-SNAPSHOT` | `3.0.0-SNAPSHOT` (unchanged — already pinned) |

The dev/snapshot Maven repo was already declared (`xp.enonicRepo('dev')` in `build.gradle`); no repo changes were needed.

### Excludes audit

The previous build configured `exclude group: 'com.enonic.xp'` on every `com.enonic.lib:*` include. After auditing the transitive graph (`./gradlew dependencies --configuration include --refresh-dependencies`) on the new SNAPSHOTs:

**Removed (all five excludes — none are needed on the XP-8 SNAPSHOTs):**
- `lib-util` — declares its XP deps as `compileOnly`, so it has no runtime transitives from `com.enonic.xp` at all. The exclude was a no-op.
- `lib-menu` — declares `xplibs.content` and `xplibs.portal` as `implementation`, so they appear transitively. But both are already declared directly on this app (`include xplibs.content`, `include xplibs.portal` at `${xpVersion} = 8.0.0-B4`) and Gradle resolves the duplicates to a single inclusion.
- `lib-landingpage` — declares its XP deps as `compileOnly`, no XP transitives.
- `lib-thymeleaf` — declares its XP deps as `compileOnly`, no XP transitives.
- `lib-urlredirect` — pulls `lib-portal` transitively, but `xplibs.portal` is already declared directly on this app at `8.0.0-B4`, so Gradle resolves the duplicate to a single inclusion (same pattern as `lib-menu`).

**Kept:** none. `build.gradle` is now a clean list of `include` declarations with no `exclude` clauses.

### Verification

- `./gradlew clean build` — green.
- `./gradlew dependencies --configuration include --refresh-dependencies` — confirms transitive XP libs from `lib-menu` and `lib-urlredirect` resolve to the same `8.0.0-B4` version as the direct `xplibs.*` includes (no version conflict). `lib-landingpage` and `lib-thymeleaf` show no XP transitives at all.
- Runtime verification (deploying the app on an XP 8 server) was **not** performed.

## Test plan

- [ ] CI green on this branch
- [ ] Optional: manual smoke test on an XP 8.0.0-B4 server once the consuming sandbox is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)