### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = corporate.theme
 appName = com.enonic.app.corporate.theme
 xpVersion = 8.0.0-B4
-version = 2.4.1-SNAPSHOT
+version = 3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bump master `version` from `2.4.1-SNAPSHOT` to `3.0.0-SNAPSHOT`, branching the XP 7 maintenance line onto `2.x` (created from tag `v2.4.0`).
- Add explicit `releaseBranch:` list (`master`, `2.x`) to `enonic/release-tools/build-and-publish` so both lines are recognized as release branches.

Follows the [app-booster](https://github.com/enonic/app-booster) pattern (master + 1.x).

A companion PR against `2.x` adds the same `releaseBranch:` block on that branch, since the action reads its release-branch list from each branch's own workflow file.

## Test plan

- [ ] CI green on `chore/bump-to-next-major`
- [ ] `enonic/release-tools/build-and-publish` runs cleanly with the new `releaseBranch` input

🤖 Generated with [Claude Code](https://claude.com/claude-code)