### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add explicit `releaseBranch:` list (`master`, `2.x`) to `enonic/release-tools/build-and-publish` on the `2.x` maintenance branch.
- Without this, push events to `2.x` won't trigger publishing because the action reads `releaseBranch:` from the branch's own workflow file.

Companion to #83 on `master`. No version bump or other content changes — that's master-only per the [app-booster](https://github.com/enonic/app-booster) reference.

## Test plan

- [ ] CI green on `chore/2.x-add-release-branch`
- [ ] After merge, push events to `2.x` are classified by `build-and-publish` as a release branch (the action's `release` output becomes `'true'` on a real version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)