### PR TITLE
Add branch:draft to runInContext #85

### DIFF
--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -16,6 +16,7 @@ function runInContext(callback) {
     let result;
     try {
         result = contextLib.run({
+            branch: 'draft',
             principals: ["role:system.admin"],
             repository: 'com.enonic.cms.' + projectData.id
         }, callback);


### PR DESCRIPTION
Closes #85.

## What

Add `branch: 'draft'` to the `contextLib.run({...})` call inside `runInContext` in `src/main/resources/main.js`.

## Why

XP 8's `InternalContext.Builder` now requires `branch` (see `core-repo/.../InternalContext.java:174`). Without it, the demo-content import fails on a fresh install:

```
INFO  com.enonic.app.corporate.theme - (/main.js) Project "corporate-theme" successfully created
INFO  com.enonic.app.corporate.theme - (/main.js) Importing "corporate-theme" data
INFO  com.enonic.app.corporate.theme - (/main.js) Error: branch is required
```

`projectLib.create` doesn't hit the branch-bound code path, so the project still gets created; the failure is in `exportLib.importNodes` inside the same `contextLib.run(...)` block. The result is a half-initialized state: project repo exists, no content.

`draft` matches the legacy XP 7 behavior (content imported to draft, users publish from Content Studio when ready) and matches what `app-superhero-blog/src/main/resources/main.js` does on XP 8.

## Verification

E2E inside `claude-dev`: built `xp-distro` 8.0.0-B4, deployed the patched jar, fresh start.

- Bundle `Started application com.enonic.app.corporate.theme bundle 117`.
- `Project "corporate-theme" successfully created` → `Importing "corporate-theme" data` → 47 nodes + 20 binaries imported, no errors.
- `GET /site/corporate-theme/draft/_/asset/.../css/bootstrap.css` → `200`, 192421 bytes.
- `GET /site/corporate-theme/draft/_/asset/.../css/main.css` → `200`, 15711 bytes.
- No ERROR/Exception lines in `server.log` from the app's bundle (only 500s caused by my own anonymous probes of draft URLs — expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)