### PR TITLE
Drop lib-util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     include libs.lib.menu
     include libs.lib.thymeleaf
     include libs.lib.urlredirect
-    include libs.lib.util
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,9 @@ landingpage = "3.0.0-SNAPSHOT"
 menu = "5.0.0-SNAPSHOT"
 thymeleaf = "3.0.0-SNAPSHOT"
 urlredirect = "4.0.0-SNAPSHOT"
-util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-landingpage = { module = "com.enonic.lib:lib-landingpage", version.ref = "landingpage" }
 lib-menu        = { module = "com.enonic.lib:lib-menu",        version.ref = "menu" }
 lib-thymeleaf   = { module = "com.enonic.lib:lib-thymeleaf",   version.ref = "thymeleaf" }
 lib-urlredirect = { module = "com.enonic.lib:lib-urlredirect", version.ref = "urlredirect" }
-lib-util        = { module = "com.enonic.lib:lib-util",        version.ref = "util" }

--- a/src/main/resources/cms/layouts/layout-1-col/layout-1-col.js
+++ b/src/main/resources/cms/layouts/layout-1-col/layout-1-col.js
@@ -1,7 +1,6 @@
 var libs = {
     portal: require('/lib/xp/portal'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util : require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 var view = resolve('layout-1-col.html');
 

--- a/src/main/resources/cms/layouts/layout-2-col/layout-2-col.js
+++ b/src/main/resources/cms/layouts/layout-2-col/layout-2-col.js
@@ -1,7 +1,6 @@
 var libs = {
     portal : require('/lib/xp/portal'),
     thymeleaf : require('/lib/thymeleaf'),
-    util : require('/lib/util'),
     shared : require('/lib/shared')
 };
 

--- a/src/main/resources/cms/layouts/layout-3-col/layout-3-col.js
+++ b/src/main/resources/cms/layouts/layout-3-col/layout-3-col.js
@@ -1,7 +1,6 @@
 var libs = {
     portal : require('/lib/xp/portal'),
     thymeleaf : require('/lib/thymeleaf'),
-    util : require('/lib/util'),
     shared : require('/lib/shared')
 };
 

--- a/src/main/resources/cms/layouts/layout-complex/layout-complex.js
+++ b/src/main/resources/cms/layouts/layout-complex/layout-complex.js
@@ -1,7 +1,6 @@
 var libs = {
     portal : require('/lib/xp/portal'),
-    thymeleaf : require('/lib/thymeleaf'),
-    util : require('/lib/util')
+    thymeleaf : require('/lib/thymeleaf')
 };
 
 var view = resolve('layout-complex.html');

--- a/src/main/resources/cms/pages/default/default.js
+++ b/src/main/resources/cms/pages/default/default.js
@@ -2,8 +2,7 @@ var libs = {
     portal: require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
     content: require('/lib/xp/content'),
-    menu: require('/lib/menu'),
-    util: require('/lib/util')
+    menu: require('/lib/menu')
 };
 
 var view = resolve('default.html');
@@ -51,7 +50,7 @@ exports.get = function (req) {
     }
     // Footer content
     // Fetching social media's icons
-    var icons = siteConfig.SocialIcon ? libs.util.data.forceArray(siteConfig.SocialIcon) : null;
+    var icons = siteConfig.SocialIcon ? (Array.isArray(siteConfig.SocialIcon) ? siteConfig.SocialIcon : [siteConfig.SocialIcon]) : null;
     var iconsList = [];
     if (icons) {
         for (var i = 0; i < icons.length; i++) {
@@ -61,7 +60,7 @@ exports.get = function (req) {
     }
     //Fetching contact information
     var items = [];
-    var companyItems = siteConfig.items ? libs.util.data.forceArray(siteConfig.items) : null;
+    var companyItems = siteConfig.items ? (Array.isArray(siteConfig.items) ? siteConfig.items : [siteConfig.items]) : null;
     if (companyItems) {
         for (var j = 0; j < companyItems.length; j++) {
             var itemKey = libs.content.get({

--- a/src/main/resources/cms/parts/article-list/article-list.js
+++ b/src/main/resources/cms/parts/article-list/article-list.js
@@ -2,7 +2,6 @@ var libs = {
 	portal:    require('/lib/xp/portal'),
 	thymeleaf: require('/lib/thymeleaf'),
 	content:   require('/lib/xp/content'),
-	util:      require('/lib/util'),
 	moment:    require('/lib/moment-2.29.4.min.js')
 };
 var view = resolve('article-list.html');
@@ -21,7 +20,7 @@ exports.get = function(req){
 		articles: config.articles || null
 	};
 
-	var selectedIds = libs.util.data.trimArray( libs.util.data.forceArray(config.articles) );
+	var selectedIds = (Array.isArray(config.articles) ? config.articles : [config.articles]).filter(function (v) { return v != null && v !== ''; });
 	var articles = libs.content.query({
 		start: 0,
 		count: config.amount,
@@ -61,13 +60,11 @@ exports.get = function(req){
 			contentTypes: [app.name + ':article'],
 			sort: "publish.from DESC, modifiedTime DESC"
 		});
-		//libs.util.log(moreArticles);
 
 		if (moreArticles.count > 0) {
 			articles.hits = articles.hits.concat(moreArticles.hits);
 		}
 	}
-//libs.util.log(articles);
 	// Fintune the data before sending back to the view.
 	for (var i = 0; i < articles.hits.length; i++) {
 		if (articles.hits[i].displayName === '') { articles.hits[i].displayName = 'TODO - add display name!'; }

--- a/src/main/resources/cms/parts/article-show/article-show.js
+++ b/src/main/resources/cms/parts/article-show/article-show.js
@@ -2,7 +2,6 @@ var libs = {
     thymeleaf: require('/lib/thymeleaf'),
     content: require('/lib/xp/content'),
     portal: require('/lib/xp/portal'),
-    util: require('/lib/util'),
     moment: require('/lib/moment-2.29.4.min.js')
 };
 
@@ -47,7 +46,7 @@ exports.get = function(req){
 			// Related content author needs to be fetched and added to the main content data.
 			if (content.data.author) {
 				var authorsHolder = [];
-				var authors = libs.util.data.forceArray(content.data.author); // Single selections will come out as strings, multiple as arrays. That makes our Thymeleaf complicated, so let's always force this data into arrays so our Thymeleaf can expect to loop if there's any data.
+				var authors = Array.isArray(content.data.author) ? content.data.author : [content.data.author]; // Single selections will come out as strings, multiple as arrays. That makes our Thymeleaf complicated, so let's always force this data into arrays so our Thymeleaf can expect to loop if there's any data.
 				for (var i = 0; i < authors.length; i++) {
 					var author = libs.content.get({
 						key: authors[i]

--- a/src/main/resources/cms/parts/button/button.js
+++ b/src/main/resources/cms/parts/button/button.js
@@ -1,8 +1,7 @@
 var libs = {
     portal : require('/lib/xp/portal'),
     thymeleaf : require('/lib/thymeleaf'),
-    content : require('/lib/xp/content'),
-    util : require('/lib/util')
+    content : require('/lib/xp/content')
 };
 var view = resolve("button.html");
 

--- a/src/main/resources/cms/parts/contact/contact.js
+++ b/src/main/resources/cms/parts/contact/contact.js
@@ -2,7 +2,6 @@ var libs={
     portal : require('/lib/xp/portal'),
     thymeleaf : require('/lib/thymeleaf'),
     content : require('/lib/xp/content'),
-    util : require('/lib/util'),
     mailLib : require('/lib/xp/mail')
 };
 

--- a/src/main/resources/cms/parts/employees/employees.js
+++ b/src/main/resources/cms/parts/employees/employees.js
@@ -1,8 +1,7 @@
 var libs = {
     portal: require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
-    content: require('/lib/xp/content'),
-    util: require('/lib/util')
+    content: require('/lib/xp/content')
 };
 
 var view = resolve('employees.html');
@@ -23,7 +22,7 @@ function getEmployeeContents(config) {
         }).hits;
     }
 
-    var employeeIds = config.team ? libs.util.data.forceArray(config.team) : null;
+    var employeeIds = config.team ? (Array.isArray(config.team) ? config.team : [config.team]) : null;
     if (!employeeIds) { return [] };
     var employeeContents = [];
     for(var i=0; i < employeeIds.length; i++) {

--- a/src/main/resources/cms/parts/partner/partner.js
+++ b/src/main/resources/cms/parts/partner/partner.js
@@ -1,8 +1,7 @@
 var libs = {
     portal : require('/lib/xp/portal'),
     thymeleaf : require('/lib/thymeleaf'),
-    content : require('/lib/xp/content'),
-    util : require('/lib/util')
+    content : require('/lib/xp/content')
 };
 
 var view = resolve('partner.html');
@@ -10,7 +9,7 @@ var view = resolve('partner.html');
 exports.get = function(req){
 
     var config = libs.portal.getComponent().config;
-    var partnerLogos = config.partnerLogo ? libs.util.data.forceArray(config.partnerLogo) : null;
+    var partnerLogos = config.partnerLogo ? (Array.isArray(config.partnerLogo) ? config.partnerLogo : [config.partnerLogo]) : null;
     var logosList = [];
 
     if(partnerLogos){

--- a/src/main/resources/cms/parts/portfolio-frontpage/portfolio-frontpage.js
+++ b/src/main/resources/cms/parts/portfolio-frontpage/portfolio-frontpage.js
@@ -2,7 +2,6 @@ var libs = {
     portal:    require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
     content:   require('/lib/xp/content'),
-    util:      require('/lib/util'),
     shared:    require('/lib/shared'),
     portfolio: require('/cms/content-types/portfolio')
 };
@@ -16,7 +15,7 @@ exports.get = function(req) {
     var config = libs.portal.getComponent().config;
 
     var contents = libs.shared.getContents(CONTENT_TYPE_PORTFOLIO, function() {
-        var ids = config.portfolio ? libs.util.data.forceArray(config.portfolio) : null;
+        var ids = config.portfolio ? (Array.isArray(config.portfolio) ? config.portfolio : [config.portfolio]) : null;
         var _contents = [];
         if(ids) {
             for(var i = 0; i < ids.length; i++ ) {

--- a/src/main/resources/cms/parts/portfolio/portfolio.js
+++ b/src/main/resources/cms/parts/portfolio/portfolio.js
@@ -2,7 +2,6 @@ var libs = {
     portal:    require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
     content:   require('/lib/xp/content'),
-    util:      require('/lib/util'),
     shared:    require('/lib/shared'),
     portfolio: require('/cms/content-types/portfolio')
 };

--- a/src/main/resources/cms/parts/service-frontpage/service-frontpage.js
+++ b/src/main/resources/cms/parts/service-frontpage/service-frontpage.js
@@ -2,7 +2,6 @@ var libs = {
     portal : require('/lib/xp/portal'),
     thymeleaf : require('/lib/thymeleaf'),
     content : require('/lib/xp/content'),
-    util : require('/lib/util'),
     shared : require('/lib/shared'),
     services: require('/cms/content-types/service')
 };
@@ -16,7 +15,7 @@ exports.get = function(req){
     var config = libs.portal.getComponent().config;
 
     var contents = libs.shared.getContents(CONTENT_TYPE_SERVICES, function() {
-        var ids = config.service ? libs.util.data.forceArray(config.service) : null;
+        var ids = config.service ? (Array.isArray(config.service) ? config.service : [config.service]) : null;
         if(ids) {
             var _contents = [];
             for(var i = 0; i < ids.length; i++ ) {

--- a/src/main/resources/cms/parts/service/service.js
+++ b/src/main/resources/cms/parts/service/service.js
@@ -2,7 +2,6 @@ var libs = {
     portal : require('/lib/xp/portal'),
     thymeleaf : require('/lib/thymeleaf'),
     content : require('/lib/xp/content'),
-    util : require('/lib/util'),
     shared : require('/lib/shared'),
     services: require('/cms/content-types/service')
 };

--- a/src/main/resources/cms/parts/slider/slider.js
+++ b/src/main/resources/cms/parts/slider/slider.js
@@ -1,8 +1,7 @@
 var libs={
     portal : require('/lib/xp/portal'),
     thymeleaf : require('/lib/thymeleaf'),
-    content : require('/lib/xp/content'),
-    util : require('/lib/util')
+    content : require('/lib/xp/content')
 };
 
 var view = resolve('slider.html');
@@ -11,7 +10,7 @@ exports.get = function(req){
 
     var component = libs.portal.getComponent();
     var banners = [];
-    var slides = component.config.banner ? libs.util.data.forceArray(component.config.banner) : null;
+    var slides = component.config.banner ? (Array.isArray(component.config.banner) ? component.config.banner : [component.config.banner]) : null;
 
     if(slides){
         for(var i = 0; i < slides.length; i++){


### PR DESCRIPTION
## Summary

Removes the `lib-util` dependency from the app.

This app only used three things from lib-util:

- `util.data.forceArray` — replaced with `Array.isArray(x) ? x : [x]`
- `util.data.trimArray` — replaced with the same wrapping plus a `.filter(function (v) { return v != null && v !== ''; })`
- `util.log` — only present in two commented-out lines in `article-list.js`; removed

Inlined at every call site (no new helper). Unused `util: require('/lib/util')` imports were removed from controllers that didn't actually call it (8 of the 16 files only had the import lying around).

Inlines are Nashorn-safe ES5: no optional chaining, no `??`, no `Object.entries`, no `Array.prototype.flat`.

### Files touched

Controllers with real call sites inlined:
- `cms/pages/default/default.js` (2× forceArray)
- `cms/parts/article-list/article-list.js` (forceArray + trimArray, plus stale commented log lines removed)
- `cms/parts/article-show/article-show.js` (forceArray)
- `cms/parts/employees/employees.js` (forceArray)
- `cms/parts/partner/partner.js` (forceArray)
- `cms/parts/portfolio-frontpage/portfolio-frontpage.js` (forceArray)
- `cms/parts/service-frontpage/service-frontpage.js` (forceArray)
- `cms/parts/slider/slider.js` (forceArray)

Controllers with only the unused import removed:
- `cms/parts/service/service.js`
- `cms/parts/button/button.js`
- `cms/parts/contact/contact.js`
- `cms/parts/portfolio/portfolio.js`
- `cms/layouts/layout-1-col/layout-1-col.js`
- `cms/layouts/layout-2-col/layout-2-col.js`
- `cms/layouts/layout-3-col/layout-3-col.js`
- `cms/layouts/layout-complex/layout-complex.js`

Dependency removal:
- `build.gradle` — dropped `include libs.lib.util`
- `gradle/libs.versions.toml` — dropped `util` version + `lib-util` library entry

## Test plan

- [x] `./gradlew clean build` passes locally
- [x] Verified `lib-util` no longer in the built `corporate.theme.jar`
- [ ] CI green