### PR TITLE
Migrate to XP 8 lib-project API

### DIFF
--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -7,9 +7,7 @@ const projectData = {
     id: 'corporate-theme',
     displayName: 'Corporate Theme',
     description: 'App to build a Corporate website',
-    readAccess: {
-        public: true
-    }
+    publicRead: true
 }
 
 function runInContext(callback) {


### PR DESCRIPTION
## Summary

XP 8 PR [enonic/xp#12043](https://github.com/enonic/xp/pull/12043) (merged 2026-05-18) flattened the project read-access shape in `/lib/xp/project`. The nested `readAccess: { public: ... }` is gone — `create` and the `Project` shape now use a top-level `publicRead: boolean` instead. There is no backward-compat shim, so the old shape fails at runtime on XP 8 master.

This PR switches `main.js`'s sample-project bootstrap from `readAccess: { public: true }` to `publicRead: true`. That is the only call site in the repo (`grep -rEn 'readAccess|modifyReadAccess' src` returns just this one); no `projectLib.modify(...)` calls exist.

See the lib-project upgrade notes in [`enonic/doc-code`](https://github.com/enonic/doc-code) → `docs/upgrade.adoc` and the new API shape in `docs/libraries/lib-project.adoc`.

## Test plan

- [x] `./gradlew build` — green
- [ ] CI passes