### PR TITLE
Import fix: content.import attr, vacuum skip

### DIFF
--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -1,33 +1,14 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:output method="xml" indent="yes"/>
-    <xsl:param name="applicationId"/>
-    <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
-    <xsl:variable name="placeholderApp" select="'com.enonic.app.corporate.theme'"/>
-    <xsl:variable name="placeholderAppDashed" select="translate($placeholderApp, '.', '-')"/>
+    <xsl:param name="keepPublishFirst" select="'true'"/>
 
-    <xsl:template match="string[starts-with(text(),concat($placeholderApp,':'))]">
-        <string>
-            <xsl:attribute name="name">
-                <xsl:value-of select="@name"/>
-            </xsl:attribute>
-            <xsl:value-of select="concat($applicationId, substring-after(.,$placeholderApp))"/>
-        </string>
-    </xsl:template>
-
-    <xsl:template match="string[text() = $placeholderApp]">
-        <string>
-            <xsl:attribute name="name">
-                <xsl:value-of select="@name"/>
-            </xsl:attribute>
-            <xsl:value-of select="$applicationId"/>
-        </string>
-    </xsl:template>
-
-    <xsl:template match="property-set/@name[. = $placeholderAppDashed]">
-        <xsl:attribute name="name">
-            <xsl:value-of select="$applicationIdDashed"/>
-        </xsl:attribute>
+    <xsl:template match="data/property-set[@name='publish']">
+        <xsl:if test="$keepPublishFirst != 'false'">
+            <xsl:copy>
+                <xsl:apply-templates select="@*|*[@name='first']"/>
+            </xsl:copy>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="@*|node()">
@@ -35,6 +16,4 @@
             <xsl:apply-templates select="@*|node()"/>
         </xsl:copy>
     </xsl:template>
-
-
 </xsl:stylesheet>

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -61,6 +61,13 @@ function createContent() {
         xsltParams: {
             applicationId: app.name
         },
+        versionAttributes: {
+            'content.import': {
+                user: "role:system.admin",
+                optime: new Date().toISOString()
+            },
+            'vacuum.skip': {}
+        },
         includeNodeIds: true
     });
     log.info('-------------------');


### PR DESCRIPTION
Mirrors [enonic/app-features#248](https://github.com/enonic/app-features/pull/248) (and [enonic/app-superhero-blog@dd30922](https://github.com/enonic/app-superhero-blog/commit/dd30922)) — the canonical fix for two related issues in the demo-app bootstrap-via-import flow.

## Summary

- Add `versionAttributes` to the `importNodes(...)` call in `main.js`: stamps imported content with `content.import` (so downstream consumers can tell the content was bootstrap-imported) and `vacuum.skip` (so vacuum cannot reclaim it).
- Replace `replace_app.xsl` placeholder-app rewriting templates with publish-fields cleanup. The old templates rewrote `placeholderApp` → `applicationId`, but `placeholderApp` equals this app's own `app.name`, so they were no-ops. The new XSLT keeps only `publish.first` during import.

`xsltParams: { applicationId: app.name }` is left in place, matching the conservative choice in app-features and app-superhero-blog — the new XSLT ignores unknown params.

## Test plan

- [x] `./gradlew build` clean