### PR TITLE
Modernize demo importer #91

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     include xplibs.mail
     include xplibs.portal
     include xplibs.project
+    include xplibs.task
 
     include libs.lib.landingpage
     include libs.lib.menu

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@
 group = com.enonic.app
 projectName = corporate.theme
 appName = com.enonic.app.corporate.theme
-xpVersion = 8.0.0-SNAPSHOT
+xpVersion = 8.0.0-RC1
 version = 3.1.0-SNAPSHOT

--- a/src/main/resources/import/my-corporation/_/node.xml
+++ b/src/main/resources/import/my-corporation/_/node.xml
@@ -2,8 +2,7 @@
     <id>840899b3-3585-4c0d-a052-2f3f2b42763e</id>
     <childOrder>_manualordervalue DESC, _timestamp DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T11:34:49.140Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:18.967Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-02-03T09:33:59.893Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -388,7 +385,7 @@
                         <indexValueProcessor>htmlStripper</indexValueProcessor>
                     </indexValueProcessors>
                 </indexConfig>
-                <path>data.siteConfig.config.freeText</path>
+                <path>data.siteconfig.config.freetext</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -401,7 +398,7 @@
                         <indexValueProcessor>htmlStripper</indexValueProcessor>
                     </indexValueProcessors>
                 </indexConfig>
-                <path>data.siteConfig.config.footerText</path>
+                <path>data.siteconfig.config.footertext</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -411,7 +408,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -564,7 +561,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -594,7 +591,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -617,6 +614,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/_templates/_/node.xml
+++ b/src/main/resources/import/my-corporation/_templates/_/node.xml
@@ -2,8 +2,7 @@
     <id>519955b2-56e7-4a5a-b3cc-8f00efd43687</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.900Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.061Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -90,10 +89,7 @@
         <string name="modifier">user:system:su</string>
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2017-02-03T09:33:59.929Z</dateTime>
-        <property-set name="publish">
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
-        </property-set>
+        <property-set name="publish"/>
         <property-set name="data"/>
         <property-set name="x">
             <property-set name="com-enonic-app-corporate-theme">
@@ -287,7 +283,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -317,7 +313,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -340,6 +336,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/_templates/articles/_/node.xml
+++ b/src/main/resources/import/my-corporation/_templates/articles/_/node.xml
@@ -2,8 +2,7 @@
     <id>a42c182d-331a-4afc-b128-fafc19981413</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.911Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.404Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2018-02-01T10:37:01.052Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data">
             <string name="supports">com.enonic.app.corporate.theme:article</string>
@@ -219,7 +216,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -372,7 +369,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -402,7 +399,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -425,6 +422,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/_templates/default/_/node.xml
+++ b/src/main/resources/import/my-corporation/_templates/default/_/node.xml
@@ -2,8 +2,7 @@
     <id>51776dee-e137-4334-befb-372f84ff4176</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.933Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.412Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -90,10 +89,7 @@
         <string name="modifier">user:system:su</string>
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2017-03-06T08:50:34.795Z</dateTime>
-        <property-set name="publish">
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
-        </property-set>
+        <property-set name="publish"/>
         <property-set name="data">
             <string name="supports">com.enonic.app.corporate.theme:landing-page</string>
             <string name="supports">portal:site</string>
@@ -290,7 +286,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -320,7 +316,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -343,6 +339,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/_templates/employee/_/node.xml
+++ b/src/main/resources/import/my-corporation/_templates/employee/_/node.xml
@@ -2,8 +2,7 @@
     <id>6251aea8-7007-4bc0-ae1d-0dbedbef1597</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.930Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.421Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-07-25T07:34:05.864Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data">
             <string name="supports">com.enonic.app.corporate.theme:employee</string>
@@ -349,7 +346,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -379,7 +376,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -402,6 +399,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/_templates/portfolio/_/node.xml
+++ b/src/main/resources/import/my-corporation/_templates/portfolio/_/node.xml
@@ -2,8 +2,7 @@
     <id>3eb31142-bbb1-498a-aae5-074dac0e8b9d</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.917Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.428Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-07-25T07:39:40.883Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data">
             <string name="supports">com.enonic.app.corporate.theme:portfolio</string>
@@ -347,7 +344,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -377,7 +374,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -400,6 +397,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/_templates/services/_/node.xml
+++ b/src/main/resources/import/my-corporation/_templates/services/_/node.xml
@@ -2,8 +2,7 @@
     <id>c73f766b-ea04-4a3c-af6c-464331a8c1c5</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.921Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.437Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-07-25T07:37:11.935Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data">
             <string name="supports">com.enonic.app.corporate.theme:service</string>
@@ -347,7 +344,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -377,7 +374,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -400,6 +397,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/about-us/_/node.xml
+++ b/src/main/resources/import/my-corporation/about-us/_/node.xml
@@ -2,8 +2,7 @@
     <id>55d5bcff-c394-4ff0-877f-bfa74353de07</id>
     <childOrder>_manualordervalue DESC, _timestamp DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T11:24:27.402Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.034Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-03-06T08:42:58.656Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -238,7 +235,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -391,7 +388,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -421,7 +418,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -444,6 +441,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/about-us/jane-robbins/Jane Robbins.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/about-us/jane-robbins/Jane Robbins.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>608e3d53-1774-4a82-8543-640bed269273</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:24:10.059Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.238Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -121,9 +120,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">Jane Robbins.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
-            <string isNull="true" name="text"/>
             <long name="size">259835</long>
             <string name="sha512">fb853164a854db60c9d136ab29a3c7ae35d40de30a9492e9b70218fa8fc4bbcf6987be79494d65d9ed799894f733d19d490118d1da21826f9bb5ac4c480a05f9</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -144,7 +143,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +213,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,7 +243,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -257,6 +256,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/about-us/jane-robbins/_/node.xml
+++ b/src/main/resources/import/my-corporation/about-us/jane-robbins/_/node.xml
@@ -2,8 +2,7 @@
     <id>f6d9c0e7-7123-4090-8c59-b8fe9eefbb32</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:24:17.911Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.209Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-03-17T09:38:47.084Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -140,7 +137,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,7 +207,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -240,7 +237,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -253,6 +250,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/about-us/john-welles/John Welles.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/about-us/john-welles/John Welles.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>a3b373f2-bc42-4331-884d-6b0ebf256947</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T11:40:00.034Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.247Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2025-10-10T09:26:55.068Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -181,7 +178,7 @@
             <string name="mimeType">image/jpeg</string>
             <long name="size">180319</long>
             <string name="sha512">43fcd1740eb2e6f6564f0f64bee5bd30af561202e24d7433e91d360c9d6ab4d975bee75a9f2ff64a997b3446f7ac3cfabd83402fce14d38b26772b572b229634</string>
-            <string isNull="true" name="text"/>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -202,7 +199,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -272,7 +269,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -302,7 +299,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -315,6 +312,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/about-us/john-welles/_/node.xml
+++ b/src/main/resources/import/my-corporation/about-us/john-welles/_/node.xml
@@ -2,8 +2,7 @@
     <id>614d11f9-019a-4493-8ed2-742fd6dbdfa3</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:27:57.558Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.216Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-03-17T09:32:00.314Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -140,7 +137,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,7 +207,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -240,7 +237,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -253,6 +250,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/about-us/mary-smith/Mary Smith.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/about-us/mary-smith/Mary Smith.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>e998dffe-e8ee-41f1-b7e1-669e3c6f2132</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:20:20.692Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.230Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -121,9 +120,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">Mary Smith.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
-            <string isNull="true" name="text"/>
             <long name="size">264187</long>
             <string name="sha512">3f5da34bd0a3cd90c89fc320098520a7736d539d9a2ba915aeef9287a6ce75bb4a4a3163105139ca6934296b72a7ade9290349169a9c4be4d573b4134fe174f8</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -144,7 +143,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +213,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,7 +243,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -257,6 +256,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/about-us/mary-smith/_/node.xml
+++ b/src/main/resources/import/my-corporation/about-us/mary-smith/_/node.xml
@@ -2,8 +2,7 @@
     <id>8848ee3a-e2b2-4f42-ac16-e33495972bd9</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:22:24.775Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.203Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-03-17T09:55:27.958Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -140,7 +137,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,7 +207,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -240,7 +237,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -253,6 +250,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/about-us/thomas-morgan/Thomas Morgan.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/about-us/thomas-morgan/Thomas Morgan.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>ad4a30f7-57a4-4f5b-8752-6141b02de037</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:29:38.596Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.259Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -121,9 +120,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">Thomas Morgan.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
-            <string isNull="true" name="text"/>
             <long name="size">310540</long>
             <string name="sha512">c9f09dc6b56bc66d71b9c9512d715b391edc0ff7fb7708b018be1dc2502fe67f94f5731116c58ec1ab1282196c4dbd48b175d976a97b07ca63964b2cb6134046</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -144,7 +143,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +213,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,7 +243,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -257,6 +256,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/about-us/thomas-morgan/_/node.xml
+++ b/src/main/resources/import/my-corporation/about-us/thomas-morgan/_/node.xml
@@ -2,8 +2,7 @@
     <id>613431cd-4356-4ff1-9305-77d7c01daaa4</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:30:05.507Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.223Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-04-10T13:32:55.909Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -140,7 +137,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,7 +207,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -240,7 +237,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -253,6 +250,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/contact/_/node.xml
+++ b/src/main/resources/import/my-corporation/contact/_/node.xml
@@ -2,8 +2,7 @@
     <id>ca8c605e-e22f-4529-84fb-73349133c868</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.748Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.006Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -90,10 +89,7 @@
         <string name="modifier">user:system:su</string>
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2017-03-06T08:44:31.294Z</dateTime>
-        <property-set name="publish">
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
-        </property-set>
+        <property-set name="publish"/>
         <property-set name="data"/>
         <property-set name="x">
             <property-set name="com-enonic-app-corporate-theme">
@@ -316,7 +312,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -346,7 +342,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -369,6 +365,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/images/Bootstrap-Tutorial.png/_/node.xml
+++ b/src/main/resources/import/my-corporation/images/Bootstrap-Tutorial.png/_/node.xml
@@ -2,8 +2,7 @@
     <id>90370b68-6b0e-4247-8eb5-ad4f839a76da</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.884Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.140Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -120,6 +119,7 @@
             <binaryReference name="binary">Bootstrap-Tutorial.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">13209</long>
+            <string name="sha512">62617d6dd84207003ceec0e41ff03fae957dd40a52f313df5c26914ee5fbd2ab706f6ea9f05d3c8dac317466b566081636fa5b0c4c4b1e6f6ac46104db300206</string>
             <string name="text"/>
         </property-set>
     </data>
@@ -200,7 +200,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -230,7 +230,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -243,6 +243,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/images/_/node.xml
+++ b/src/main/resources/import/my-corporation/images/_/node.xml
@@ -2,8 +2,7 @@
     <id>fac543f2-8fbd-4aaa-a498-ddb55928d512</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.852Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.028Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-03-05T20:01:40.794Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data"/>
         <property-set name="x">
@@ -192,7 +189,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -222,7 +219,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -235,6 +232,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/images/client1.png/_/node.xml
+++ b/src/main/resources/import/my-corporation/images/client1.png/_/node.xml
@@ -2,8 +2,7 @@
     <id>916480d8-01aa-4909-8bf5-5d91409cf103</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.868Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.148Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -120,6 +119,7 @@
             <binaryReference name="binary">client1.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">11259</long>
+            <string name="sha512">4f697bc6fd9bffa5dc2864ef1123f4e4dfc78477940963bde680a06892d5d959bdddd5db38c246dbfb650d82e1fbd050d9c494f9f8e5b8804ba2d6bca379d04f</string>
             <string name="text"/>
         </property-set>
     </data>
@@ -200,7 +200,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -230,7 +230,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -243,6 +243,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/images/client2.png/_/node.xml
+++ b/src/main/resources/import/my-corporation/images/client2.png/_/node.xml
@@ -2,8 +2,7 @@
     <id>b4d29df4-aef7-44d6-9c14-ce02e867840a</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.880Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.155Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -120,6 +119,7 @@
             <binaryReference name="binary">client2.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">13930</long>
+            <string name="sha512">d35dafa14313f85abc110d03352b0eb2d91788eb94bcec4b2a5a1e7c9e78d483f3038380df60d9dfb0054f07f7560598265da5331256b2d0659d81e0e4f20d37</string>
             <string name="text"/>
         </property-set>
     </data>
@@ -200,7 +200,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -230,7 +230,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -243,6 +243,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/images/client3.png/_/node.xml
+++ b/src/main/resources/import/my-corporation/images/client3.png/_/node.xml
@@ -2,8 +2,7 @@
     <id>fde46648-07b5-4d4f-9f6f-a951bd088eb4</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.872Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.162Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -120,6 +119,7 @@
             <binaryReference name="binary">client3.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">10900</long>
+            <string name="sha512">1fa0b37b2a3bcc8ed9d93f81b6b7ebd918bdf260ccd6df529f64f61ba26ac6a6528d34cce97ae29e17c32647b605d982e4b5484e865ceeeb0a9cc1a49c79464a</string>
             <string name="text"/>
         </property-set>
     </data>
@@ -200,7 +200,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -230,7 +230,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -243,6 +243,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/images/client4.png/_/node.xml
+++ b/src/main/resources/import/my-corporation/images/client4.png/_/node.xml
@@ -2,8 +2,7 @@
     <id>3f0debde-17ba-4fd5-b189-f37c8ee321b2</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.861Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.169Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -120,6 +119,7 @@
             <binaryReference name="binary">client4.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">12919</long>
+            <string name="sha512">6e3cab926ec0f35f938b5074bc04b60712aa844eb8bd1ed2d4d0d047f75b558665ec5480aaa65f6517d806af390663edf7d1da3b54494acd9e0ebc6c9f9908cd</string>
             <string name="text"/>
         </property-set>
     </data>
@@ -200,7 +200,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -230,7 +230,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -243,6 +243,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/images/img1.png/_/node.xml
+++ b/src/main/resources/import/my-corporation/images/img1.png/_/node.xml
@@ -2,8 +2,7 @@
     <id>9d6d1269-1944-4d2e-8ad2-a83fa3470d01</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.897Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.177Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -120,6 +119,7 @@
             <binaryReference name="binary">img1.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">224239</long>
+            <string name="sha512">39d83b1ef00ee8554af81ee9bb95ab6461c1f7fa09e04d092e0e504f0c50766eb0539f8443410d21280c0a526bf125041ba69aa82ea8c90ec510fea6ffd342a4</string>
             <string name="text"/>
         </property-set>
     </data>
@@ -200,7 +200,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -230,7 +230,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -243,6 +243,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/images/img2.png/_/node.xml
+++ b/src/main/resources/import/my-corporation/images/img2.png/_/node.xml
@@ -2,8 +2,7 @@
     <id>23e10ece-6e3b-4dad-8a89-1c54e31f7098</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.893Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.185Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -120,6 +119,7 @@
             <binaryReference name="binary">img2.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">373954</long>
+            <string name="sha512">987107ca1052b339e29041cc6ca408eb2ca5e5f60d9dbd7cf109a4c3b510c6a63d01e0209b6b9f6ff013b2974286d7dafc8ddb5ddffce40a33e70acdc4b922f4</string>
             <string name="text"/>
         </property-set>
     </data>
@@ -200,7 +200,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -230,7 +230,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -243,6 +243,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/images/img3.png/_/node.xml
+++ b/src/main/resources/import/my-corporation/images/img3.png/_/node.xml
@@ -2,8 +2,7 @@
     <id>81bca7c3-04a9-4ac0-ba66-cbe484af0bc7</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.889Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.191Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -120,6 +119,7 @@
             <binaryReference name="binary">img3.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">88252</long>
+            <string name="sha512">e1e6151ab625672484bd2091f4ece95b66267aafe892493e107958aff425c8de2a5fb539e75e329be7ac63eb9073b55e1c2970b0bfa648c8d9b762684d6d63fc</string>
             <string name="text"/>
         </property-set>
     </data>
@@ -200,7 +200,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -230,7 +230,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -243,6 +243,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/images/logo.svg/_/node.xml
+++ b/src/main/resources/import/my-corporation/images/logo.svg/_/node.xml
@@ -2,8 +2,7 @@
     <id>b038fbac-9aa7-430f-9f6e-b5238599f970</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T07:36:45.822Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.198Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -105,9 +104,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">logo.svg</binaryReference>
             <string name="mimeType">image/svg+xml</string>
-            <string isNull="true" name="text"/>
             <long name="size">11126</long>
             <string name="sha512">48deb58a13d33e36659f5429a0c12d771ff2000bef86ce5864af452f8c7725876a6ab6a3e686cfe983b8c96e54ca9b8341e92ce7093841299b5269b0429e49b5</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -128,7 +127,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -198,7 +197,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -228,7 +227,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -241,6 +240,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/more/_/node.xml
+++ b/src/main/resources/import/my-corporation/more/_/node.xml
@@ -2,8 +2,7 @@
     <id>be3714be-0cc0-4451-a14d-443f81a7a191</id>
     <childOrder>_manualordervalue DESC, _timestamp DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.818Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.023Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-08-02T08:01:09.762Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data"/>
         <property-set name="x">
@@ -192,7 +189,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -222,7 +219,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -235,6 +232,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/more/layouts/_/node.xml
+++ b/src/main/resources/import/my-corporation/more/layouts/_/node.xml
@@ -2,8 +2,7 @@
     <id>06091395-191f-47f8-8a8f-6946bfb0b2eb</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.825Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.109Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2018-02-01T09:38:22.914Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data"/>
         <property-set name="x">
@@ -218,7 +215,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -371,7 +368,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -401,7 +398,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -424,6 +421,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/more/privacy-policy/_/node.xml
+++ b/src/main/resources/import/my-corporation/more/privacy-policy/_/node.xml
@@ -2,8 +2,7 @@
     <id>21c0102d-abaf-4344-9bd5-e2c0d1feafbc</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.837Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.118Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -90,10 +89,7 @@
         <string name="modifier">user:system:su</string>
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2017-04-04T06:41:16.086Z</dateTime>
-        <property-set name="publish">
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
-        </property-set>
+        <property-set name="publish"/>
         <property-set name="data"/>
         <property-set name="x">
             <property-set name="com-enonic-app-corporate-theme">
@@ -329,7 +325,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -359,7 +355,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -382,6 +378,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/more/terms-of-use/_/node.xml
+++ b/src/main/resources/import/my-corporation/more/terms-of-use/_/node.xml
@@ -2,8 +2,7 @@
     <id>ff38a5bc-2717-4c92-9141-8b70d57f5deb</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.843Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.129Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -90,10 +89,7 @@
         <string name="modifier">user:system:su</string>
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2017-04-04T06:47:31.665Z</dateTime>
-        <property-set name="publish">
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
-        </property-set>
+        <property-set name="publish"/>
         <property-set name="data"/>
         <property-set name="x">
             <property-set name="com-enonic-app-corporate-theme">
@@ -335,7 +331,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -365,7 +361,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -388,6 +384,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/news/_/node.xml
+++ b/src/main/resources/import/my-corporation/news/_/node.xml
@@ -2,8 +2,7 @@
     <id>752861c1-44de-49be-8389-41880e89c05a</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.754Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.015Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2018-02-01T09:46:10.282Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data"/>
         <property-set name="x">
@@ -203,7 +200,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -356,7 +353,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -386,7 +383,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -409,6 +406,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/news/reinventing-the-wheel/_/node.xml
+++ b/src/main/resources/import/my-corporation/news/reinventing-the-wheel/_/node.xml
@@ -2,8 +2,7 @@
     <id>ec8ad090-9927-406f-a068-6014ba0bf1df</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T11:43:10.457Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.069Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2025-10-10T11:40:57.645Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -164,7 +161,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -247,7 +244,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -277,7 +274,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -290,6 +287,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/news/the-company-acquires-the-firm-in-landmark-deal/Business Buildings.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/news/the-company-acquires-the-firm-in-landmark-deal/Business Buildings.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>a3814bec-8068-47fa-bcff-af5c12703b17</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T11:45:03.070Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.100Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -121,9 +120,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">Business Buildings.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
-            <string isNull="true" name="text"/>
             <long name="size">546237</long>
             <string name="sha512">774b5e9ee29fbccc8d29f41fb22e9625488f2cb30b4b1c6feb5335e24cb034b8f036e7e89f5d540e693ac0bf7b2d8a105a1a224a66582c7a09732e7920b4adf6</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -144,7 +143,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +213,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,7 +243,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -257,6 +256,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/news/the-company-acquires-the-firm-in-landmark-deal/_/node.xml
+++ b/src/main/resources/import/my-corporation/news/the-company-acquires-the-firm-in-landmark-deal/_/node.xml
@@ -2,8 +2,7 @@
     <id>f6d65e00-9294-4ab3-8853-4541578d0ecb</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T11:45:38.194Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.079Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2025-10-10T11:43:18.506Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -145,7 +142,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -228,7 +225,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -258,7 +255,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -271,6 +268,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/news/the-company-hires-new-ceo/_/node.xml
+++ b/src/main/resources/import/my-corporation/news/the-company-hires-new-ceo/_/node.xml
@@ -2,8 +2,7 @@
     <id>d48391a8-5299-47f0-89f4-fecad34c0200</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T11:40:17.567Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.089Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2025-10-10T11:37:28.703Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -153,7 +150,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -236,7 +233,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -266,7 +263,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -279,6 +276,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/_/node.xml
@@ -2,8 +2,7 @@
     <id>862c8cc2-3b18-4657-ad91-59b24fd657f0</id>
     <childOrder>_manualordervalue DESC, _timestamp DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.649Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.050Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-03-01T09:42:07.105Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data"/>
         <property-set name="x">
@@ -362,7 +359,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -392,7 +389,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -415,6 +412,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/bottomless-flask/Flask.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/bottomless-flask/Flask.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>79a18608-53d2-46bf-84c1-98d38d293923</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:36:57.237Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.378Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -121,9 +120,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">Flask.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
-            <string isNull="true" name="text"/>
             <long name="size">50485</long>
             <string name="sha512">9b101b380cff789ae6392b8ee857071e9ec1e6a6de84f798f30a48e461939e158f8d9b117b4fe9588d6e546f2ad848b8511480ba22f41430eaf3b7780dc91f7e</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -144,7 +143,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +213,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,7 +243,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -257,6 +256,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/bottomless-flask/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/bottomless-flask/_/node.xml
@@ -2,8 +2,7 @@
     <id>a876ebc3-093d-4ea0-aa15-70efa52de397</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:36:57.175Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.337Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-04-10T10:22:09.309Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -131,7 +128,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -201,7 +198,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -231,7 +228,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,6 +241,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/everlasting-light-bulb/Light Bulb.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/everlasting-light-bulb/Light Bulb.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>a46d40fc-5064-45b1-bc01-71103f802b16</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:32:32.949Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.364Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -121,9 +120,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">Light Bulb.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
-            <string isNull="true" name="text"/>
             <long name="size">177890</long>
             <string name="sha512">1c42a30339bfa89ba023df79d63d70d2b68274581d4c3630cd369d909dcf636ad7cd0551a0f4ab5278b321f9ee46bde38d9431fa1f2df44eaed469fd0e198111</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -144,7 +143,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +213,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,7 +243,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -257,6 +256,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/everlasting-light-bulb/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/everlasting-light-bulb/_/node.xml
@@ -2,8 +2,7 @@
     <id>c186c62f-4903-489f-ad11-58103ddd043a</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:33:38.337Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.327Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-04-10T10:32:07.768Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -131,7 +128,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -201,7 +198,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -231,7 +228,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,6 +241,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/home-robot-assistant/Robot.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/home-robot-assistant/Robot.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>745c481c-12b7-4d5e-a87f-9c099098079e</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:38:24.436Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.387Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -121,9 +120,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">Robot.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
-            <string isNull="true" name="text"/>
             <long name="size">337452</long>
             <string name="sha512">a4b54a7ded78978b0581497f63f778a582542bcde5cc30625b9469513d13838fe23cec1219f6bea88d8aad981c22504451407e4bb167daecbd6dcf6a6dc18737</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -144,7 +143,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +213,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,7 +243,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -257,6 +256,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/home-robot-assistant/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/home-robot-assistant/_/node.xml
@@ -2,8 +2,7 @@
     <id>c2ff1fda-3be4-4a3e-98c1-50f257053f0c</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T11:17:23.590Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.342Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-03-16T13:08:30.112Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -131,7 +128,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -201,7 +198,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -231,7 +228,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,6 +241,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/puncture-free-wheel/Wheel.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/puncture-free-wheel/Wheel.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>0b38d3df-fd30-404a-b3ef-39906cb41516</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:35:14.348Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.371Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -121,9 +120,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">Wheel.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
-            <string isNull="true" name="text"/>
             <long name="size">350518</long>
             <string name="sha512">cc3d6ed59181b0dbf67dcdb8d39eb53ba6854a3b930bcc15f08588abc8a093331d9c0bce43a9fc5e4564fb9d9dbb9be944aae4360433e07cae30944a127f899a</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -144,7 +143,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +213,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,7 +243,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -257,6 +256,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/puncture-free-wheel/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/puncture-free-wheel/_/node.xml
@@ -2,8 +2,7 @@
     <id>448bcaee-45d9-41d8-9e44-66391273a009</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:35:14.230Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.332Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-03-16T13:09:37.628Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -131,7 +128,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -201,7 +198,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -231,7 +228,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,6 +241,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/transportation-portal/Portal.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/transportation-portal/Portal.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>3bdd74f9-a0fc-4130-9c14-43af2a06bee0</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:40:22.517Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.396Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -121,9 +120,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">Portal.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
-            <string isNull="true" name="text"/>
             <long name="size">405314</long>
             <string name="sha512">c1ab7fa8b2b55ddff9943b1411a671f163e67e9709bffaa4ecaf0ebb5a4a4b8c71c2c279035581edaa14c6cf0c1e3430709484eec2e073cc731599469f4c04d6</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -144,7 +143,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +213,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,7 +243,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -257,6 +256,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/transportation-portal/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/transportation-portal/_/node.xml
@@ -2,8 +2,7 @@
     <id>794d5440-098c-4c8b-956b-56823a22033c</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:43:01.998Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.350Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-04-10T10:28:49.733Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -131,7 +128,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -201,7 +198,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -231,7 +228,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,6 +241,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/wings/Wings.jpg/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/wings/Wings.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>04cfa227-8df6-4b53-a030-d6fbf21b2885</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:42:15.025Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.357Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -121,9 +120,9 @@
             <string name="label">source</string>
             <binaryReference name="binary">Wings.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
-            <string isNull="true" name="text"/>
             <long name="size">334766</long>
             <string name="sha512">70cac664574b0fa30db18ffa6416f209408a034893ce6f5aba5d4290fb897a42ea0ea1de4163aa0bdc1995bd0d3cd4ef5cd1b651b7d61b131a70b1762ec8ce75</string>
+            <string name="text"/>
         </property-set>
     </data>
     <indexConfigs>
@@ -144,7 +143,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +213,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,7 +243,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -257,6 +256,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/portfolio/wings/_/node.xml
+++ b/src/main/resources/import/my-corporation/portfolio/wings/_/node.xml
@@ -2,8 +2,7 @@
     <id>88686739-5263-4d4e-b6a2-c887fddd56da</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T09:42:14.999Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.320Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-04-10T10:22:34.709Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -131,7 +128,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -201,7 +198,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -231,7 +228,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -244,6 +241,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/services/_/node.xml
+++ b/src/main/resources/import/my-corporation/services/_/node.xml
@@ -2,8 +2,7 @@
     <id>3ba4273e-0f84-4c10-b27c-54717bc14d71</id>
     <childOrder>_manualordervalue DESC, _timestamp DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.593Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.043Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-03-06T08:43:35.472Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data"/>
         <property-set name="x">
@@ -355,7 +352,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -385,7 +382,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -408,6 +405,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/services/android-application-development/_/node.xml
+++ b/src/main/resources/import/my-corporation/services/android-application-development/_/node.xml
@@ -2,8 +2,7 @@
     <id>5dd0ac91-d5f8-4129-adba-d306575878ca</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.615Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.287Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -90,10 +89,7 @@
         <string name="modifier">user:system:su</string>
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2017-04-06T13:18:09.621Z</dateTime>
-        <property-set name="publish">
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
-        </property-set>
+        <property-set name="publish"/>
         <property-set name="data">
             <string name="serviceIntro">Proin gravida nibh vel velit auctor aliquet. Aenean sollicitudin, lorem quis bibendum auctor, nisi elit consequat ipsum, nec sagittis sem nibh id elit. Duis sed odio sit amet nibh vulputate cursus a sit amet mauris. Morbi accumsan ipsum velit. Nam nec tellus a odio tincidunt auctor a ornare odio.</string>
             <string name="serviceIcon">bullhorn</string>
@@ -184,7 +180,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +210,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -227,6 +223,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/services/ios-application-development/_/node.xml
+++ b/src/main/resources/import/my-corporation/services/ios-application-development/_/node.xml
@@ -2,8 +2,7 @@
     <id>eb7ccf69-0167-44a2-9558-c19e69a86b0d</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.621Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.294Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -90,10 +89,7 @@
         <string name="modifier">user:system:su</string>
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2017-04-06T13:16:05.807Z</dateTime>
-        <property-set name="publish">
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
-        </property-set>
+        <property-set name="publish"/>
         <property-set name="data">
             <string name="serviceIntro">Proin gravida nibh vel velit auctor aliquet. Aenean sollicitudin, lorem quis bibendum auctor, nisi elit consequat ipsum, nec sagittis sem nibh id elit. Duis sed odio sit amet nibh vulputate cursus a sit amet mauris. Morbi accumsan ipsum velit. Nam nec tellus a odio tincidunt auctor a ornare odio.</string>
             <string name="serviceIcon">camera</string>
@@ -184,7 +180,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +210,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -227,6 +223,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/services/premium-bootstrap-templates/_/node.xml
+++ b/src/main/resources/import/my-corporation/services/premium-bootstrap-templates/_/node.xml
@@ -2,8 +2,7 @@
     <id>56d67e28-2a10-4e14-a730-8d7f84270cfc</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.642Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.315Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -90,10 +89,7 @@
         <string name="modifier">user:system:su</string>
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2017-03-06T11:04:17.714Z</dateTime>
-        <property-set name="publish">
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
-        </property-set>
+        <property-set name="publish"/>
         <property-set name="data">
             <string name="serviceIntro">Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</string>
             <string name="serviceIcon">leaf</string>
@@ -184,7 +180,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +210,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -227,6 +223,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/services/premium-enonic-xp-themes/_/node.xml
+++ b/src/main/resources/import/my-corporation/services/premium-enonic-xp-themes/_/node.xml
@@ -2,8 +2,7 @@
     <id>b18f909d-d2c5-43f4-a1ba-1b295a0ef890</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.607Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.272Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -89,11 +88,9 @@
         <dateTime name="modifiedTime">2017-07-07T10:32:07.764Z</dateTime>
         <string name="modifier">user:system:su</string>
         <string name="creator">user:system:su</string>
-        <dateTime name="createdTime">2017-03-06T11:15:42.000Z</dateTime>
+        <dateTime name="createdTime">2017-03-06T11:15:42Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="data">
             <string name="serviceIntro">Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.por sit amet, ante. Donec eu libero sit amet quam egestas spor sit amet, ante. Donec eu libero sit amet quam egestas s</string>
@@ -195,7 +192,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -225,7 +222,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -238,6 +235,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/services/responsive-web-design/_/node.xml
+++ b/src/main/resources/import/my-corporation/services/responsive-web-design/_/node.xml
@@ -2,8 +2,7 @@
     <id>29d4ad0d-1378-4fce-8323-4070b803959d</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-26T12:46:09.624Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.303Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -90,10 +89,7 @@
         <string name="modifier">user:system:su</string>
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2017-03-08T09:34:56.395Z</dateTime>
-        <property-set name="publish">
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
-        </property-set>
+        <property-set name="publish"/>
         <property-set name="data">
             <string name="serviceIntro">Proin gravida nibh vel velit auctor aliquet. Aenean sollicitudin, lorem quis bibendum auctor, nisi elit consequat ipsum, nec sagittis sem nibh id elit. Duis sed odio sit amet nibh vulputate cursus a sit amet mauris. Morbi accumsan ipsum velit. Nam nec tellus a odio tincidunt auctor a ornare odio.</string>
             <string name="serviceIcon">globe</string>
@@ -184,7 +180,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -214,7 +210,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -227,6 +223,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/my-corporation/services/web-design-development/_/node.xml
+++ b/src/main/resources/import/my-corporation/services/web-design-development/_/node.xml
@@ -2,8 +2,7 @@
     <id>a660ffd4-dae2-4fd5-bca3-dc432c32d61c</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2025-10-10T11:30:01.321Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:52:19.309Z</timestamp>
     <permissions>
         <principal key="role:system.everyone">
             <allow type="array">
@@ -92,8 +91,6 @@
         <dateTime name="createdTime">2017-03-06T11:08:05.206Z</dateTime>
         <property-set name="publish">
             <dateTime isNull="true" name="first"/>
-            <dateTime isNull="true" name="from"/>
-            <dateTime isNull="true" name="to"/>
         </property-set>
         <property-set name="workflow">
             <string name="state">READY</string>
@@ -130,7 +127,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -200,7 +197,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -230,7 +227,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -243,6 +240,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -1,19 +1,54 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-    <xsl:output method="xml" indent="yes"/>
-    <xsl:param name="keepPublishFirst" select="'true'"/>
+  <xsl:output method="xml" indent="yes"/>
 
-    <xsl:template match="data/property-set[@name='publish']">
-        <xsl:if test="$keepPublishFirst != 'false'">
-            <xsl:copy>
-                <xsl:apply-templates select="@*|*[@name='first']"/>
-            </xsl:copy>
-        </xsl:if>
-    </xsl:template>
+  <xsl:param name="applicationId"/>
+  <xsl:param name="projectName"/>
+  <xsl:param name="keepPublishFirst" select="'true'"/>
 
-    <xsl:template match="@*|node()">
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()"/>
-        </xsl:copy>
-    </xsl:template>
+  <!-- Values the bundled /import data was exported with -->
+  <xsl:variable name="applicationIdPlaceholder" select="'com.enonic.app.corporate.theme'"/>
+  <xsl:variable name="projectNamePlaceholder" select="'corporate-theme'"/>
+
+  <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
+  <xsl:variable name="applicationIdPlaceholderDashed" select="translate($applicationIdPlaceholder, '.', '-')"/>
+
+  <!-- app key inside descriptor-style string values: "<app>:descriptor" -->
+  <xsl:template match="string[starts-with(text(), concat($applicationIdPlaceholder, ':'))]">
+    <string>
+      <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+      <xsl:value-of select="concat($applicationId, substring-after(., $applicationIdPlaceholder))"/>
+    </string>
+  </xsl:template>
+
+  <!-- bare app key string value -->
+  <xsl:template match="string[text() = $applicationIdPlaceholder]">
+    <string>
+      <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+      <xsl:value-of select="$applicationId"/>
+    </string>
+  </xsl:template>
+
+  <!-- dashed app key in property-set names (x.<dashed-app>...) -->
+  <xsl:template match="property-set/@name[. = $applicationIdPlaceholderDashed]">
+    <xsl:attribute name="name"><xsl:value-of select="$applicationIdDashed"/></xsl:attribute>
+  </xsl:template>
+
+  <!-- project-role principals: role:cms.project.<placeholder>.<suffix> -->
+  <xsl:template match="principal/@key[starts-with(., concat('role:cms.project.', $projectNamePlaceholder, '.'))]">
+    <xsl:attribute name="key">
+      <xsl:value-of select="concat('role:cms.project.', $projectName, '.', substring-after(., concat('role:cms.project.', $projectNamePlaceholder, '.')))"/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy><xsl:apply-templates select="@*|node()"/></xsl:copy>
+  </xsl:template>
+
+  <!-- Remove publishing metadata on import -->
+  <xsl:template match="data/property-set[@name='publish']">
+    <xsl:if test="$keepPublishFirst != 'false'">
+      <xsl:copy><xsl:apply-templates select="@*|*[@name='first']"/></xsl:copy>
+    </xsl:if>
+  </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -1,22 +1,29 @@
-const projectLib = require('/lib/xp/project');
 const contextLib = require('/lib/xp/context');
+const contentLib = require('/lib/xp/content');
 const clusterLib = require('/lib/xp/cluster');
 const exportLib = require('/lib/xp/export');
+const projectLib = require('/lib/xp/project');
+const taskLib = require('/lib/xp/task');
 
 const projectData = {
     id: 'corporate-theme',
     displayName: 'Corporate Theme',
     description: 'App to build a Corporate website',
-    publicRead: true
+    readAccess: {
+        public: true
+    }
 }
 
-function runInContext(callback) {
+const runInContext = function (callback) {
     let result;
     try {
         result = contextLib.run({
-            branch: 'draft',
-            principals: ["role:system.admin"],
-            repository: 'com.enonic.cms.' + projectData.id
+            user: {
+                login: "su",
+                idProvider: "system"
+            },
+            repository: 'com.enonic.cms.' + projectData.id,
+            branch: 'draft'
         }, callback);
     } catch (e) {
         log.info('Error: ' + e.message);
@@ -25,33 +32,44 @@ function runInContext(callback) {
     return result;
 }
 
-function createProject() {
+const createProject = function () {
     return projectLib.create(projectData);
 }
 
-function getProject() {
+const getProject = function () {
     return projectLib.get({
         id: projectData.id
     });
 }
 
-function initializeProject() {
-    let project = runInContext(getProject);
+const initialize = function () {
+    runInContext(() => {
+        const project = getProject();
+        if (!project) {
+            taskLib.executeFunction({
+                description: 'Importing content',
+                func: initProject
+            });
+        }
+        else {
+            log.debug(`Project ${project.id} exists, skipping import`);
+        }
+    });
+};
 
-    if (!project) {
-        log.info('Project "' + projectData.id + '" not found. Creating...');
-        project = runInContext(createProject);
+const initProject = function () {
+    runInContext(() => {
+        const project = createProject();
 
         if (project) {
             log.info('Project "' + projectData.id + '" successfully created');
-
-            log.info('Importing "' + projectData.id + '" data');
-            runInContext(createContent);
+            createContent();
+            publishRoot();
         } else {
-            log.error('Project "' + projectData.id + '" failed to be created');
+            log.error('Project "' + projectData.id + '" creation failed');
         }
-    }
-}
+    });
+};
 
 function createContent() {
     let importNodes = exportLib.importNodes({
@@ -59,34 +77,40 @@ function createContent() {
         targetNodePath: '/content',
         xslt: resolve('/import/replace_app.xsl'),
         xsltParams: {
-            applicationId: app.name
+            applicationId: app.name,
+            projectName: projectData.id
         },
         versionAttributes: {
             'content.import': {
-                user: "role:system.admin",
+                user: contextLib.get().authInfo.user.key,
                 optime: new Date().toISOString()
             },
             'vacuum.skip': {}
         },
         includeNodeIds: true
     });
-    log.info('-------------------');
-    log.info('Imported nodes:');
-    importNodes.addedNodes.forEach(element => log.info(element));
-    log.info('-------------------');
-    log.info('Updated nodes:');
-    importNodes.updatedNodes.forEach(element => log.info(element));
-    log.info('-------------------');
-    log.info('Imported binaries:');
-    importNodes.importedBinaries.forEach(element => log.info(element));
-    log.info('-------------------');
-    if (importNodes.importErrors.length !== 0) {
+    if (importNodes.importErrors.length > 0) {
         log.warning('Errors:');
         importNodes.importErrors.forEach(element => log.warning(element.message));
         log.info('-------------------');
     }
 }
 
-if (clusterLib.isMaster()) {
-    initializeProject();
+function publishRoot() {
+    const result = contentLib.publish({
+        keys: ['/my-corporation'],
+        sourceBranch: 'draft',
+        targetBranch: 'master',
+        includeChildren: true,
+        includeDependencies: true,
+    });
+    if (!result || (result.failedContents && result.failedContents.length > 0)) {
+        log.warning('Could not publish imported content. failed=' + JSON.stringify(result && result.failedContents));
+    } else {
+        log.info('Published ' + (result.pushedContents ? result.pushedContents.length : 0) + ' content items.');
+    }
+}
+
+if (clusterLib.isLeader()) {
+    initialize();
 }


### PR DESCRIPTION
Closes #91.

## Summary

Brings the bundled demo importer up to the same standard as the merged
[`app-superhero-blog#174`](https://github.com/enonic/app-superhero-blog/pull/174),
[`app-hmdb#80`](https://github.com/enonic/app-hmdb/pull/80), and
[`app-image-xpert#54`](https://github.com/enonic/app-image-xpert/pull/54).
Note: this app was *partially* on the new pattern already (50/56 nodes had
the project-role principals, 12/20 media nodes had `sha512`) — the re-export +
sha512 pass normalizes ALL nodes uniformly so the end state is consistent.

### `src/main/resources/import/replace_app.xsl`

Now fully parameter-driven. Takes:

- `applicationId` + `projectName` (live values, passed from `main.js`)
- `keepPublishFirst` (default `'true'`)

Placeholder values that the bundled `/import/my-corporation` data was
exported with (`com.enonic.app.corporate.theme` / `corporate-theme`) live as
`<xsl:variable>` inside the stylesheet, so callers don't need to know them.
Templates rewrite:

- `string` starting with `<placeholder>:` → app prefix swapped to
  `$applicationId`
- bare `<placeholder>` string value → `$applicationId`
- `property-set/@name` matching the dashed app placeholder → dashed
  `$applicationId`
- `principal/@key` starting with `role:cms.project.<placeholder>.` →
  project segment swapped to `$projectName`
- `data/property-set[@name='publish']` stripped (kept only `first`)

Forks that rename either the app key or the project id now get correct
descriptor refs and `role:cms.project.<new-id>.*` principals on imported
content.

### `src/main/resources/main.js`

Modernized to match the merged superhero/hmdb/image-xpert pattern:

- `projectData.readAccess.public = true` (replaces `publicRead: true`)
- `runInContext` uses `user: { login: 'su', idProvider: 'system' }` (drops
  `principals: ['role:system.admin']`)
- `xsltParams` passes only the live targets (`applicationId: app.name`,
  `projectName: projectData.id`)
- `versionAttributes['content.import'].user` is
  `contextLib.get().authInfo.user.key` instead of the hardcoded role
- `publishRoot()` added — calls `contentLib.publish` with
  `includeChildren: true`, `includeDependencies: true`, inspects
  `failedContents`, logs `pushedContents.length`
- guard switched to `clusterLib.isLeader()`
- `taskLib.executeFunction({ description, func })` wraps the import

### Re-exported `/import/my-corporation` data

The 56 bundled `node.xml` files now uniformly carry the five canonical
project-role principals (`role:cms.project.corporate-theme.{owner,editor,author,contributor,viewer}`)
alongside `role:system.admin` / `role:cms.admin` / `role:system.everyone`,
applied via `contentLib.applyPermissions(scope: 'TREE')` in a one-off
bootstrap, then exported via `exportLib.exportNodes` and copied back.

All 20 media nodes get `<string name="sha512">HASH</string>` +
`<string name="text"/>` injected after `<long name="size">…</long>` in
their `attachment` property-set, where `HASH` is `sha512sum` of the
corresponding `_/bin/<file>` binary (matching what XP would compute on
ingest). Any pre-existing `<string isNull="true" name="text"/>` further
down in the attachment block is removed in the same pass. The 12 nodes
that already had a `sha512` retained their (verified-correct) hashes;
the 8 that didn't were filled in.

### Other

- `gradle.properties`: `xpVersion` bumped `8.0.0-SNAPSHOT` → `8.0.0-RC1`
  to pin against the readAccess-based lib-project API.
- `build.gradle`: added `include xplibs.task` (for `taskLib.executeFunction`).

## Test plan

E2E inside `claude-dev` against `xp-distro` 8.0.0-RC1:

- [x] `./gradlew build` green
- [x] Fresh xp-distro install, jar deployed, server.log shows:
  - `Started application com.enonic.app.corporate.theme`
  - `Project "corporate-theme" successfully created`
  - `Published 56 content items.`
  - no import errors / warnings
- [x] Source `/import/my-corporation` carries all five
  `role:cms.project.corporate-theme.*` principals on every node (56 × 5 =
  280 occurrences)
- [x] Every media `node.xml` has a `<string name="sha512">` matching
  `sha512sum` of the linked `_/bin/<file>` (20 / 20)