### PR TITLE
GraalJS Compatibility #96

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,30 @@ dependencies {
     include libs.lib.menu
     include libs.lib.thymeleaf
     include libs.lib.urlredirect
+
+    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
     mavenCentral()
     xp.enonicRepo('dev')
 }
+
+test {
+    useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -35,14 +34,6 @@ test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@
 group = com.enonic.app
 projectName = corporate.theme
 appName = com.enonic.app.corporate.theme
-xpVersion = 8.0.2
+xpVersion = 8.1.0-SNAPSHOT
 version = 3.1.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -3,7 +3,6 @@ const contentLib = require('/lib/xp/content');
 const clusterLib = require('/lib/xp/cluster');
 const exportLib = require('/lib/xp/export');
 const projectLib = require('/lib/xp/project');
-const taskLib = require('/lib/xp/task');
 
 const projectData = {
     id: 'corporate-theme',
@@ -44,15 +43,8 @@ const getProject = function () {
 
 const initialize = function () {
     runInContext(() => {
-        const project = getProject();
-        if (!project) {
-            taskLib.executeFunction({
-                description: 'Importing content',
-                func: initProject
-            });
-        }
-        else {
-            log.debug(`Project ${project.id} exists, skipping import`);
+        if (!getProject()) {
+            initProject();
         }
     });
 };

--- a/src/test/java/com/enonic/app/corporate/theme/MainScriptTest.java
+++ b/src/test/java/com/enonic/app/corporate/theme/MainScriptTest.java
@@ -1,0 +1,13 @@
+package com.enonic.app.corporate.theme;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class MainScriptTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/test/main-test.js";
+    }
+}

--- a/src/test/resources/test/main-test.js
+++ b/src/test/resources/test/main-test.js
@@ -1,0 +1,72 @@
+var t = require('/lib/xp/testing');
+
+var calls = {
+    projectGet: 0,
+    projectCreate: 0,
+    importNodes: 0,
+    publish: 0,
+    createdId: null
+};
+
+t.mock('/lib/xp/context.js', {
+    run: function (params, callback) {
+        return callback();
+    },
+    get: function () {
+        return {
+            authInfo: {
+                user: {
+                    key: 'user:system:su'
+                }
+            }
+        };
+    }
+});
+
+t.mock('/lib/xp/cluster.js', {
+    isLeader: function () {
+        return true;
+    }
+});
+
+t.mock('/lib/xp/project.js', {
+    get: function () {
+        calls.projectGet++;
+        return null;
+    },
+    create: function (params) {
+        calls.projectCreate++;
+        calls.createdId = params.id;
+        return {
+            id: params.id
+        };
+    }
+});
+
+t.mock('/lib/xp/export.js', {
+    importNodes: function () {
+        calls.importNodes++;
+        return {
+            importErrors: []
+        };
+    }
+});
+
+t.mock('/lib/xp/content.js', {
+    publish: function () {
+        calls.publish++;
+        return {
+            pushedContents: ['/my-corporation']
+        };
+    }
+});
+
+require('/main.js');
+
+exports.testInitImportsContentWhenProjectMissing = function () {
+    t.assertEquals(1, calls.projectGet, 'getProject should be called once');
+    t.assertEquals(1, calls.projectCreate, 'createProject should be called once');
+    t.assertEquals('corporate-theme', calls.createdId, 'created project id');
+    t.assertEquals(1, calls.importNodes, 'content should be imported');
+    t.assertEquals(1, calls.publish, 'root content should be published');
+};


### PR DESCRIPTION
Fixes #96

## What

`task.executeFunction` offloaded initialization onto another thread. GraalJS cannot honor that — a function is bound to the context that created it — so the call **fails fast** and the app never initializes on that engine.

The offload no longer has a purpose either: enonic/xp#12198 holds every top-level execution until `main.js` has finished (fixes enonic/xp#7821), so the rest of the app already sees an initialized app. `initialize()` now calls the function directly, exactly as the issue prescribes:

```js
if (!getProject()) {
    initProject();
}
```

No named task, no `executeFunction`. The `description` is lost, which only affected the task list. The now-unused `require('/lib/xp/task')` is dropped as well; the `include xplibs.task` bundle dependency is left untouched (out of scope).

## Tested on both engines

The JS test now runs once per script engine — Nashorn via `test`, GraalJS via `testGraalJs` — both wired into `check`, mirroring `gradle/js-tests.gradle` in the platform. The new `MainScriptTest` loads `main.js` with the platform libs mocked (leader = true, no existing project) and asserts the full init path runs **synchronously during load**: `project.create` → `export.importNodes` → `content.publish`. The old offloaded-task form would not satisfy those assertions, and on GraalJS it would not run at all.

```
test         1 test, 0 failed   (Nashorn)
testGraalJs  1 test, 0 failed   (GraalJS)
```

Verified green on both engines against a local `publishToMavenLocal` build of enonic/xp#12198.

## Note on `xpVersion` and draft status

The bump to `8.1.0-SNAPSHOT` (and `enonicRepo('dev')`, already present) is required by `testGraalJs`, not by the fix itself — the fix alone is green on Nashorn under 8.0.2.

`MainScriptTest` extends `ScriptRunnerSupport`, whose `findTestNames()` closed the script executor before the dynamic tests ran. On GraalJS every test then failed with `IllegalStateException` / `PolyglotEngineException` regardless of this app's code. That is fixed in enonic/xp#12198 ("keep the script executor alive through JS test discovery"), so:

- verified green above against a local build of that branch;
- **CI `testGraalJs` will stay red until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published** — the snapshot currently on `repo.enonic.com/dev` still carries the old `ScriptRunnerSupport`. Nashorn `test` stays green.

Holding this as a **draft** until then. Reference: enonic/lib-sql#154.
